### PR TITLE
37202187: fix ContactUsModal (scroll and overlay)

### DIFF
--- a/apps/xi.land/components/HomePage/ContactUsModal.tsx
+++ b/apps/xi.land/components/HomePage/ContactUsModal.tsx
@@ -84,7 +84,7 @@ const ContactUsModal = ({ children, ...props }: ContactUsModalProps) => {
   // При закрытии окна изменять значение в параметрах URL на false
   const onClose = () => {
     const updatedParams = deleteQuery(searchParams, 'contact-us');
-    router.push(`${pathname}?${updatedParams}`);
+    router.push(`${pathname}?${updatedParams}`, { scroll: false });
     props.setModalOpen(false);
   };
 
@@ -92,7 +92,7 @@ const ContactUsModal = ({ children, ...props }: ContactUsModalProps) => {
   useEffect(() => {
     if (props.open) {
       const updatedParams = createQueryString(searchParams, 'contact-us', 'true');
-      router.push(`${pathname}?${updatedParams}`);
+      router.push(`${pathname}?${updatedParams}`, { scroll: false });
     }
   }, [props.open]);
 

--- a/apps/xi.land/components/HomePage/ContactUsModal.tsx
+++ b/apps/xi.land/components/HomePage/ContactUsModal.tsx
@@ -81,18 +81,19 @@ const ContactUsModal = ({ children, ...props }: ContactUsModalProps) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // При закрытии окна изменять значение в параметрах URL на false
   const onClose = () => {
-    const updatedParams = deleteQuery(searchParams, 'contact-us');
-    router.push(`${pathname}?${updatedParams}`, { scroll: false });
     props.setModalOpen(false);
   };
 
   // При открытии окна изменять параметры в URL на true
+  // При закрытии окна изменять значение в параметрах URL на false
   useEffect(() => {
     if (props.open) {
       const updatedParams = createQueryString(searchParams, 'contact-us', 'true');
       router.push(`${pathname}?${updatedParams}`, { scroll: false });
+    } else {
+      const updatedParams = deleteQuery(searchParams, 'contact-us');
+      router.replace(`${pathname}?${updatedParams}`, { scroll: false });
     }
   }, [props.open]);
 

--- a/apps/xi.land/package.json
+++ b/apps/xi.land/package.json
@@ -15,7 +15,7 @@
     "@xipkg/icons": "^0.9.3",
     "@xipkg/input": "0.1.1",
     "@xipkg/link": "^0.3.0",
-    "@xipkg/modal": "^1.4.0",
+    "@xipkg/modal": "^3.0.0",
     "@xipkg/routerurl": "^0.2.0",
     "@xipkg/tabs": "1.1.0",
     "@xipkg/tailwind": "0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@xipkg/icons": "^0.9.3",
         "@xipkg/input": "0.1.1",
         "@xipkg/link": "^0.3.0",
-        "@xipkg/modal": "^1.4.0",
+        "@xipkg/modal": "^3.0.0",
         "@xipkg/routerurl": "^0.2.0",
         "@xipkg/tabs": "1.1.0",
         "@xipkg/tailwind": "0.5.0",
@@ -159,28 +159,6 @@
       },
       "peerDependencies": {
         "react": "^18"
-      }
-    },
-    "apps/xi.vacancy/node_modules/@xipkg/modal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xipkg/modal/-/modal-3.0.0.tgz",
-      "integrity": "sha512-VtcckCNKmMPoo/hoM7Jk5Zd0fMcajtGcTa1G1MmIbEh5ne3gyG1dcIX7lFbBRltAAgRNPKO7WEU+I5lwOrwmJQ==",
-      "dependencies": {
-        "@radix-ui/react-dialog": "1.0.4",
-        "@xipkg/icons": "^0.8.2",
-        "@xipkg/utils": "^1.0.1",
-        "lucide-react": "0.276.0"
-      },
-      "peerDependencies": {
-        "react": "^18"
-      }
-    },
-    "apps/xi.vacancy/node_modules/@xipkg/modal/node_modules/@xipkg/icons": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xipkg/icons/-/icons-0.8.6.tgz",
-      "integrity": "sha512-mhF8fhh3nJ7E7bGkHxbVS9Ti5tShhsa1hVb16DZVq8cprBRXiAb8WZRDc+lXbrK/qXjOaY7bW5zLK75npWZ+uA==",
-      "dependencies": {
-        "react": "^18.2.0"
       }
     },
     "apps/xi.vacancy/node_modules/@xipkg/typescript": {
@@ -2351,15 +2329,17 @@
       }
     },
     "node_modules/@xipkg/modal": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@xipkg/modal/-/modal-1.5.0.tgz",
-      "integrity": "sha512-UyzTQkL1SojCxcs7C9w4Ro+YrtWPvav7KR1A4trNX+64ZKzXpTlNLvXLTsf/rQYdELhnEnaESjrUHM4srwwmDA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@xipkg/modal/-/modal-3.1.0.tgz",
+      "integrity": "sha512-mn0iVec/t9v6elOBr+5puTU3cZUAyzAvEL13UsC8n8AwwhDL7PuKqYPFqiZ4OsXudCznIslX7a4fIpJ9GyDbag==",
       "dependencies": {
         "@radix-ui/react-dialog": "1.0.4",
         "@xipkg/icons": "^0.8.2",
         "@xipkg/utils": "^1.0.1",
-        "lucide-react": "0.276.0",
-        "react": "^18.2.0"
+        "lucide-react": "0.276.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
       }
     },
     "node_modules/@xipkg/modal/node_modules/@xipkg/icons": {


### PR DESCRIPTION
обновила используемую версию @xipkg/modal и запретила прокрутку к верху страницы при открытии/закрытии модалки.
Не было в задании, но решила сделать так, чтобы /?contact-us=true удалялось не только по клику на кнопку закрытия модалки, но и при клике на оверлей. Также заменила router.push на router.replace, когда закрывается модалка и удаляются параметры. Если это было лишним, отменю последний коммит